### PR TITLE
My attempt to make ffprobe utility in the snap package available

### DIFF
--- a/files/bin/ffprobe-wrapper
+++ b/files/bin/ffprobe-wrapper
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+case "$SNAP_ARCH" in
+    "amd64") ARCH='x86_64-linux-gnu'
+    ;;
+    "i386") ARCH='i386-linux-gnu'
+    ;;
+    *)
+        echo "Unsupported architecture for this app build"
+        exit 1
+    ;;
+esac
+
+VENDOR=$(glxinfo | grep "OpenGL vendor")
+
+if [[ $VENDOR == *"Intel"* ]]; then
+  export VDPAU_DRIVER_PATH="$SNAP/usr/lib/$ARCH/dri"
+  export LIBVA_DRIVERS_PATH="$SNAP/usr/lib/dri"
+fi
+
+if [[ $VENDOR == *"NVIDIA"* ]]; then
+  export VDPAU_DRIVER_PATH="/var/lib/snapd/lib/gl/vdpau"
+elif [[ $VENDOR == *"X.Org"* ]]; then
+  export VDPAU_DRIVER_PATH="/usr/lib/$ARCH/vdpau/"
+fi
+
+exec $SNAP/usr/bin/ffprobe "$@"

--- a/snap/gui/ffprobe.desktop
+++ b/snap/gui/ffprobe.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Encoding=UTF-8
+Name=FFprobe
+Exec=ffprobe
+Icon=${SNAP}/meta/gui/ffmpeg.png
+Type=Application
+Terminal=true
+Categories=AudioVideo;
+NoDisplay=true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -635,7 +635,9 @@ parts:
 
 apps:
   ffmpeg:
-    command: usr/bin/ffmpeg
+    command: 
+      - usr/bin/ffmpeg
+      - usr/bin/ffprobe
     #plugs:
     #  - alsa
     #  - camera


### PR DESCRIPTION
This is an attempt to make the ffprobe utility available to end users automatically. 

Can someone test this? 

Does this need some additions in the test.sh file to verify that ffprobe is functional or is it safe to assume that it works as long as ffmpeg works?

See [issue #3](https://github.com/snapcrafters/ffmpeg/issues/3) for more information.