### PR TITLE
Fix libvpx support. Closes #17

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -193,6 +193,7 @@ parts:
       - --disable-unit-tests
       - --as=yasm
     prime:
+      - usr/lib
       - -usr/include
       - -usr/lib/pkgconfig
     after:
@@ -520,6 +521,7 @@ parts:
       - --enable-libtwolame
       - --enable-libv4l2
       - --enable-libvorbis
+      - --enable-libvpx
       - --enable-libx264
       - --enable-libx265
       - --enable-libxcb


### PR DESCRIPTION
Prime libvpx and add `--enable-libvpx` to ffmpeg part configflags. 