### PR TITLE
Make intel i965 va driver x86/64 only

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,7 +87,10 @@ parts:
       - on i386:
         - libcrystalhd-dev
     stage-packages:
-      - i965-va-driver
+      - on amd64:
+          - i965-va-driver
+      - on i386:
+          - i965-va-driver
       - libass9
       - libdrm2
       - libgnutls30


### PR DESCRIPTION
Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>