### PR TITLE
Added libGL environment fix for other applications

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -226,6 +226,15 @@ apps:
       - x11
   ffprobe:
     command: bin/ffprobe
+    environment:
+      # Tell libGL where to find the drivers
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri
+      # Mesa Libs for OpenGL support
+      # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
+      # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
+      # Without that OpenGL using apps do not work with the nVidia drivers.
+      # Ref.: https://bugs.launchpad.net/snappy/+bug/1588192
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-egl:$LIBGL_DRIVERS_PATH:/var/lib/snapd/lib/gl
     plugs:
       - alsa
       - camera
@@ -242,6 +251,15 @@ apps:
       - x11
   ffplay:
     command: bin/ffplay
+    environment:
+      # Tell libGL where to find the drivers
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri
+      # Mesa Libs for OpenGL support
+      # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
+      # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
+      # Without that OpenGL using apps do not work with the nVidia drivers.
+      # Ref.: https://bugs.launchpad.net/snappy/+bug/1588192
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-egl:$LIBGL_DRIVERS_PATH:/var/lib/snapd/lib/gl
     plugs:
       - alsa
       - camera


### PR DESCRIPTION
This is necessary to fix libGL errors with Intel drivers equivalent to those described in #16.