### PR TITLE
Bump srt to latest upstream release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,7 +47,7 @@ parts:
   srt:
     plugin: cmake
     source: https://github.com/Haivision/srt.git
-    source-tag: 'v1.4.3'
+    source-tag: 'v1.4.4'
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This is a minor version bump (`1.4.3` to `1.4.4`). There are lots of fixes detailed in the release notes: https://github.com/Haivision/srt/releases/tag/v1.4.4
