### PR TITLE
Bump aom version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,7 +93,7 @@ parts:
   aom:
     plugin: cmake
     source: https://aomedia.googlesource.com/aom.git
-    source-tag: 'v3.1.0'
+    source-tag: 'v3.2.0'
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This is a minor upstream release (`3.1.0` to `3.2.0`). There are perceptual and performance improvements: https://aomedia.googlesource.com/aom.git/+/refs/tags/v3.2.0/CHANGELOG
