### PR TITLE
Bump dav1d version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,7 +115,7 @@ parts:
   dav1d:
     plugin: meson
     source: https://code.videolan.org/videolan/dav1d.git
-    source-tag: '0.9.0'
+    source-tag: '0.9.2'
     meson-parameters:
       - --prefix=/usr
       - --buildtype=release


### PR DESCRIPTION
Minor upstream version bump (`0.9.0` to `0.9.2`). This includes performance improvements, and 10bit support: https://code.videolan.org/videolan/dav1d/-/blob/0.9.2/NEWS
