### PR TITLE
Bump zimg version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -133,7 +133,7 @@ parts:
   zimg:
     plugin: autotools
     source: https://github.com/sekrit-twc/zimg.git
-    source-tag: 'release-3.0.1'
+    source-tag: 'release-3.0.3'
     autotools-configure-parameters:
       - --prefix=/usr
     prime:


### PR DESCRIPTION
This is a minor upstream release (`3.0.1` to `3.0.3`). Included are mostly bug fixes, along with some performance optimizations for amd zen3 cpus: https://github.com/sekrit-twc/zimg/blob/release-3.0.3/ChangeLog
