### PR TITLE
Migrate to use the FFmpeg content snap

### DIFF
--- a/snap/local/content-snap-executable-wrapper
+++ b/snap/local/content-snap-executable-wrapper
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Wrapper script to launch the content snap executables
+
+set_opts=(
+    # Terminate script execution when an unhandled error occurs
+    -o errexit
+
+    # Terminate script execution when an unset parameter variable is
+    # referenced
+    -o nounset
+)
+if ! set "${set_opts[@]}"; then
+    printf \
+        'content-snap-executable-wrapper: Error: Unable to configure the defensive interpreter behaviors.\n' \
+        1>&2
+    exit 1
+fi
+
+if ! trap 'printf "content-snap-executable-wrapper: Error: The program has encountered an unhandled error and is prematurely aborted.\\n" 1>&2' ERR; then
+    printf \
+        'content-snap-executable-wrapper: Error: Unable to set the ERR trap.\n' \
+        1>&2
+    exit 1
+fi
+
+base_command="${0##*/}"
+
+ffmpeg_exe="${SNAP}/ffmpeg-platform/usr/bin/${base_command}"
+mesa_exe="${SNAP}/gpu-2404/usr/bin/${base_command}"
+self_exe="${SNAP}/usr/bin/${base_command}"
+if test -e "${ffmpeg_exe}"; then
+	executable="${ffmpeg_exe}"
+elif test -e "${mesa_exe}"; then
+	executable="${mesa_exe}"
+elif test -e "${self_exe}"; then
+	executable="${self_exe}"
+else
+    printf \
+        'content-snap-executable-wrapper: Error: Unable to locate the executable for command "%s".\n' \
+        "${base_command}" \
+		1>&2
+    exit 1
+fi
+
+if ! exec "${executable}" "$@"; then
+    printf \
+        'content-snap-executable-wrapper: Error: exec failed.\n' \
+        1>&2
+    exit 1
+fi

--- a/snap/local/desktop-glib-only/desktop-launch
+++ b/snap/local/desktop-glib-only/desktop-launch
@@ -268,7 +268,7 @@ fi
 
 # Check if we can actually read the contents of each xdg dir
 for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
-  if ! can_open_file "${XDG_SPECIAL_DIRS_PATHS[$i]}"; then
+  if can_open_file "${XDG_SPECIAL_DIRS_PATHS[$i]}"; then
     needs_xdg_update=true
     needs_xdg_links=true
     break

--- a/snap/local/desktop-glib-only/desktop-launch
+++ b/snap/local/desktop-glib-only/desktop-launch
@@ -1,0 +1,551 @@
+#!/bin/bash
+#################
+# Launcher init #
+#################
+
+START=$(date +%s.%N)
+
+declare -A PIDS
+function async_exec() {
+  $@ &
+  PIDS[$!]=$@
+}
+function wait_for_async_execs() {
+  for i in ${!PIDS[@]}
+  do
+    wait $i && continue || echo "ERROR: ${PIDS[$i]} exited abnormally with status $?"
+  done
+}
+
+# ensure_dir_exists calls `mkdir -p` if the given path is not a directory.
+# This speeds up execution time by avoiding unnecessary calls to mkdir.
+#
+# Usage: ensure_dir_exists <path> [<mkdir-options>]...
+#
+function ensure_dir_exists() {
+  [ -d "$1" ] ||  mkdir -p "$@"
+}
+
+# On Fedora $SNAP is under /var and there is some magic to map it to /snap.
+# # We need to handle that case and reset $SNAP
+SNAP=`echo $SNAP | sed -e "s|/var/lib/snapd||g"`
+
+needs_update=true
+
+. $SNAP_USER_DATA/.last_revision 2>/dev/null || true
+if [ "$SNAP_DESKTOP_LAST_REVISION" = "$SNAP_REVISION" ]; then
+  needs_update=false
+fi
+
+# Set $REALHOME to the users real home directory
+REALHOME=`getent passwd $UID | cut -d ':' -f 6`
+
+# Set config folder to local path
+export XDG_CONFIG_HOME=$SNAP_USER_DATA/.config
+ensure_dir_exists $XDG_CONFIG_HOME -m 700
+
+# If the user has modified their user-dirs settings, force an update
+if [[ -f "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum" ]]; then
+  if [[ "$(md5sum < "$REALHOME/.config/user-dirs.dirs")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum")" ||
+        ( -f "$XDG_CONFIG_HOME/user-dirs.locale.md5sum" &&
+          "$(md5sum < "$REALHOME/.config/user-dirs.locale")" != "$(cat "$XDG_CONFIG_HOME/user-dirs.locale.md5sum")" ) ]]; then
+    needs_update=true
+  fi
+else
+  needs_update=true
+fi
+
+if [ "$SNAP_ARCH" == "amd64" ]; then
+  ARCH="x86_64-linux-gnu"
+elif [ "$SNAP_ARCH" == "armhf" ]; then
+  ARCH="arm-linux-gnueabihf"
+elif [ "$SNAP_ARCH" == "arm64" ]; then
+  ARCH="aarch64-linux-gnu"
+elif [ "$SNAP_ARCH" == "ppc64el" ]; then
+  ARCH="powerpc64le-linux-gnu"
+else
+  ARCH="$SNAP_ARCH-linux-gnu"
+fi
+
+export SNAP_LAUNCHER_ARCH_TRIPLET=$ARCH
+
+# Don't LD_PRELOAD bindtextdomain for classic snaps
+if ! grep -qs "^\s*confinement:\s*classic\s*" $SNAP/meta/snap.yaml; then
+  if [ -f $SNAP/lib/bindtextdomain.so ]; then
+    export LD_PRELOAD=$LD_PRELOAD:$SNAP/lib/bindtextdomain.so
+  fi
+fi
+###############################################
+# Launcher common exports for any desktop app #
+###############################################
+
+function prepend_dir() {
+  local var="$1"
+  local dir="$2"
+  if [ -d "$dir" ]; then
+    eval "export $var=\"\$dir\${$var:+:\$$var}\""
+  fi
+}
+
+function append_dir() {
+  local var="$1"
+  local dir="$2"
+  if [ -d "$dir" ]; then
+    eval "export $var=\"\${$var:+\$$var:}\$dir\""
+  fi
+}
+
+function can_open_file() {
+  return `head -c0 "$1" &> /dev/null`;
+}
+
+function update_xdg_dirs_values() {
+  local save_initial_values=false
+  local XDG_DIRS="DOCUMENTS DESKTOP DOWNLOAD MUSIC PICTURES VIDEOS PUBLICSHARE TEMPLATES"
+  unset XDG_SPECIAL_DIRS_PATHS
+
+  if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" ]; then
+    source "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
+  fi
+
+  if [ -z ${XDG_SPECIAL_DIRS+x} ]; then
+    save_initial_values=true
+  fi
+
+  for d in $XDG_DIRS; do
+    var="XDG_${d}_DIR"
+    value="$(eval echo $(echo \$${var}))"
+
+    if [ "$save_initial_values" = true ]; then
+      XDG_SPECIAL_DIRS+=("$var")
+      XDG_SPECIAL_DIRS_INITIAL_PATHS+=("$value")
+    fi
+
+    XDG_SPECIAL_DIRS_PATHS+=("$value")
+  done
+}
+
+function is_subpath() {
+  dir=$(realpath $1)
+  parent=$(realpath $2)
+  [ "${dir##$parent/}" != "$dir" ] && return 0 || return 1
+}
+
+WITH_RUNTIME=no
+if [ -z "$RUNTIME" ]; then
+  RUNTIME=$SNAP
+else
+  # add general paths not added by snapcraft due to runtime snap
+  append_dir LD_LIBRARY_PATH $RUNTIME/lib/$ARCH
+  append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib
+  append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH
+  append_dir PATH $RUNTIME/usr/bin
+  WITH_RUNTIME=yes
+fi
+
+# XKB config
+export XKB_CONFIG_ROOT=$RUNTIME/usr/share/X11/xkb
+
+# Give XOpenIM a chance to locate locale data.
+# This is required for text input to work in SDL2 games.
+export XLOCALEDIR=$RUNTIME/usr/share/X11/locale
+
+# Set XCursors path
+export XCURSOR_PATH=$RUNTIME/usr/share/icons
+prepend_dir XCURSOR_PATH $SNAP/data-dir/icons
+
+# Mesa Libs for OpenGL support
+append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/mesa
+append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/mesa-egl
+
+# Tell libGL and libva where to find the drivers
+export LIBGL_DRIVERS_PATH=$RUNTIME/usr/lib/$ARCH/dri
+append_dir LD_LIBRARY_PATH $LIBGL_DRIVERS_PATH
+export LIBVA_DRIVERS_PATH=$RUNTIME/usr/lib/$ARCH/dri
+
+# Set where the VDPAU drivers are located
+export VDPAU_DRIVER_PATH="/usr/lib/$ARCH/vdpau/"
+if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
+  export VDPAU_DRIVER_PATH="/var/lib/snapd/lib/gl/vdpau"
+  # Prevent picking VA-API (Intel/AMD) over NVIDIA VDPAU; on PRIME systems for example
+  unset LIBVA_DRIVERS_PATH
+fi
+
+# Unity7 export (workaround for https://launchpad.net/bugs/1638405)
+append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/libunity
+
+# Pulseaudio export
+append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/pulseaudio
+
+# EGL vendor files on glvnd enabled systems
+[ -d /var/lib/snapd/lib/glvnd/egl_vendor.d ] && \
+    prepend_dir __EGL_VENDOR_LIBRARY_DIRS /var/lib/snapd/lib/glvnd/egl_vendor.d
+
+# EGL vendor files
+append_dir __EGL_VENDOR_LIBRARY_DIRS $RUNTIME/etc/glvnd/egl_vendor.d
+append_dir __EGL_VENDOR_LIBRARY_DIRS $RUNTIME/usr/share/glvnd/egl_vendor.d
+
+# Tell GStreamer where to find its plugins
+export GST_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/gstreamer-1.0
+export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0
+# gst plugin scanner doesn't install in the correct path: https://github.com/ubuntu/snapcraft-desktop-helpers/issues/43
+export GST_PLUGIN_SCANNER=$RUNTIME/usr/lib/$ARCH/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner
+
+# XDG Config
+[ "$WITH_RUNTIME" = yes ] && prepend_dir XDG_CONFIG_DIRS $RUNTIME/etc/xdg
+prepend_dir XDG_CONFIG_DIRS $SNAP/etc/xdg
+
+# Define snaps' own data dir
+[ "$WITH_RUNTIME" = yes ] && prepend_dir XDG_DATA_DIRS $RUNTIME/usr/share
+prepend_dir XDG_DATA_DIRS $SNAP/usr/share
+prepend_dir XDG_DATA_DIRS $SNAP/share
+prepend_dir XDG_DATA_DIRS $SNAP/data-dir
+prepend_dir XDG_DATA_DIRS $SNAP_USER_DATA
+
+# Set XDG_DATA_HOME to local path
+export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
+ensure_dir_exists $XDG_DATA_HOME -m 700
+
+# Workaround for GLib < 2.53.2 not searching for schemas in $XDG_DATA_HOME:
+#   https://bugzilla.gnome.org/show_bug.cgi?id=741335
+prepend_dir XDG_DATA_DIRS $XDG_DATA_HOME
+
+# Set cache folder to local path
+export XDG_CACHE_HOME=$SNAP_USER_COMMON/.cache
+if [[ -d $SNAP_USER_DATA/.cache && ! -e $XDG_CACHE_HOME ]]; then
+  # the .cache directory used to be stored under $SNAP_USER_DATA, migrate it
+  mv $SNAP_USER_DATA/.cache $SNAP_USER_COMMON/
+fi
+ensure_dir_exists $XDG_CACHE_HOME -m 700
+
+# Create $XDG_RUNTIME_DIR if not exists (to be removed when LP: #1656340 is fixed)
+ensure_dir_exists $XDG_RUNTIME_DIR -m 700
+
+# Ensure the app finds locale definitions (requires locales-all to be installed)
+append_dir LOCPATH $RUNTIME/usr/lib/locale
+
+# If any, keep track of where XDG dirs were so we can potentially migrate the content later
+update_xdg_dirs_values
+
+# Setup user-dirs.* or run xdg-user-dirs-update if needed
+needs_xdg_update=false
+needs_xdg_reload=false
+needs_xdg_links=false
+
+if [ "$HOME" != "$SNAP_USER_DATA" ] && ! is_subpath "$XDG_CONFIG_HOME" "$HOME"; then
+  for f in user-dirs.dirs user-dirs.locale; do
+    if [ -f "$HOME/.config/$f" ]; then
+      mv "$HOME/.config/$f" "$XDG_CONFIG_HOME"
+      needs_xdg_reload=true
+    fi
+  done
+fi
+
+if can_open_file "$REALHOME/.config/user-dirs.dirs"; then
+  # shellcheck disable=SC2154
+  if [ "$needs_update" = true ] || [ "$needs_xdg_reload" = true ]; then
+    sed "/^#/!s#\$HOME#${REALHOME}#g" "$REALHOME/.config/user-dirs.dirs" > "$XDG_CONFIG_HOME/user-dirs.dirs"
+    md5sum < "$REALHOME/.config/user-dirs.dirs" > "$XDG_CONFIG_HOME/user-dirs.dirs.md5sum"
+    # It's possible user-dirs.dirs exists when user-dirs.locale doesn't. This
+    # simply means the user opted to never ask to translate their user dirs
+    if can_open_file "$REALHOME/.config/user-dirs.locale"; then
+      cp -a "$REALHOME/.config/user-dirs.locale" "$XDG_CONFIG_HOME"
+      md5sum < "$REALHOME/.config/user-dirs.locale" > "$XDG_CONFIG_HOME/user-dirs.locale.md5sum"
+    elif [ -f "$XDG_CONFIG_HOME/user-dirs.locale.md5sum" ]; then
+      rm "$XDG_CONFIG_HOME/user-dirs.locale.md5sum"
+    fi
+    needs_xdg_reload=true
+  fi
+else
+  needs_xdg_update=true
+  needs_xdg_links=true
+fi
+
+if [ $needs_xdg_reload = true ]; then
+  update_xdg_dirs_values
+  needs_xdg_reload=false
+fi
+
+# Check if we can actually read the contents of each xdg dir
+for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
+  if ! can_open_file "${XDG_SPECIAL_DIRS_PATHS[$i]}"; then
+    needs_xdg_update=true
+    needs_xdg_links=true
+    break
+  fi
+done
+
+# If needs XDG update and xdg-user-dirs-update exists in $PATH, run it
+if [ $needs_xdg_update = true ] && command -v xdg-user-dirs-update >/dev/null; then
+  xdg-user-dirs-update
+  update_xdg_dirs_values
+fi
+
+# Create links for user-dirs.dirs
+if [ $needs_xdg_links = true ]; then
+  for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
+    b=$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME")
+    if [[ "$b" != "." && -e $REALHOME/$b ]]; then
+      [ -d $HOME/$b ] && rmdir $HOME/$b 2> /dev/null
+      [ ! -e $HOME/$b ] && ln -s $REALHOME/$b $HOME/$b
+    fi
+  done
+else
+  # If we aren't creating new links, check if we have content saved in old locations and move it
+  for ((i = 0; i < ${#XDG_SPECIAL_DIRS[@]}; i++)); do
+    old="${XDG_SPECIAL_DIRS_INITIAL_PATHS[$i]}"
+    new="${XDG_SPECIAL_DIRS_PATHS[$i]}"
+    if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old" 2>/dev/null` != "$new" ] &&
+         (is_subpath "$old" "$SNAP_USER_DATA" || is_subpath "$old" "$SNAP_USER_COMMON"); then
+      mv -vn "$old"/* "$new"/ 2>/dev/null
+    elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ] &&
+         (is_subpath "$old" "$SNAP_USER_DATA" || is_subpath "$old" "$SNAP_USER_COMMON"); then
+      mv -vn "$old"/* "$new"/ 2>/dev/null
+    fi
+  done
+fi
+
+# If detect wayland server socket, then set environment so applications prefer
+# wayland, and setup compat symlink (until we use user mounts. Remember,
+# XDG_RUNTIME_DIR is /run/user/<uid>/snap.$SNAP so look in the parent directory
+# for the socket. For details:
+# https://forum.snapcraft.io/t/wayland-dconf-and-xdg-runtime-dir/186/10
+# Applications that don't support wayland natively may define DISABLE_WAYLAND
+# (to any non-empty value) to skip that logic entirely.
+wayland_available=false
+if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
+    wdisplay="wayland-0"
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+        wdisplay="$WAYLAND_DISPLAY"
+    fi
+    wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
+    wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
+    if [ -S "$wayland_sockpath" ]; then
+        # if running under wayland, use it
+        #export WAYLAND_DEBUG=1
+        wayland_available=true
+        # create the compat symlink for now
+        if [ ! -e "$wayland_snappath" ]; then
+            ln -s "$wayland_sockpath" "$wayland_snappath"
+        fi
+    fi
+fi
+
+# Make PulseAudio socket available inside the snap-specific $XDG_RUNTIME_DIR
+if [ -n "$XDG_RUNTIME_DIR" ]; then
+    pulsenative="pulse/native"
+    pulseaudio_sockpath="$XDG_RUNTIME_DIR/../$pulsenative"
+    if [ -S "$pulseaudio_sockpath" ]; then
+        export PULSE_SERVER="unix:${pulseaudio_sockpath}"
+    fi
+fi
+
+# GI repository
+[ "$WITH_RUNTIME" = yes ] && prepend_dir GI_TYPELIB_PATH $RUNTIME/usr/lib/$ARCH/girepository-1.0
+[ "$WITH_RUNTIME" = yes ] && prepend_dir GI_TYPELIB_PATH $RUNTIME/usr/lib/girepository-1.0
+prepend_dir GI_TYPELIB_PATH $SNAP/usr/lib/$ARCH/girepository-1.0
+prepend_dir GI_TYPELIB_PATH $SNAP/usr/lib/girepository-1.0
+prepend_dir GI_TYPELIB_PATH $SNAP/usr/lib/gjs/girepository-1.0
+
+# Keep an array of data dirs, for looping through them
+IFS=':' read -r -a data_dirs_array <<< "$XDG_DATA_DIRS"
+
+# Font Config and themes
+export FONTCONFIG_PATH=$RUNTIME/etc/fonts
+export FONTCONFIG_FILE=$RUNTIME/etc/fonts/fonts.conf
+
+function make_user_fontconfig {
+  echo "<fontconfig>"
+  if [ -d $REALHOME/.local/share/fonts ]; then
+    echo "  <dir>$REALHOME/.local/share/fonts</dir>"
+  fi
+  if [ -d $REALHOME/.fonts ]; then
+    echo "  <dir>$REALHOME/.fonts</dir>"
+  fi
+  for ((i = 0; i < ${#data_dirs_array[@]}; i++)); do
+    if [ -d "${data_dirs_array[$i]}/fonts" ]; then
+      echo "  <dir>${data_dirs_array[$i]}/fonts</dir>"
+    fi
+  done
+  # fix font render for modified fonts, that discussed on Snapcraft Forum:
+  # https://forum.snapcraft.io/t/snap-package-cannot-read-fonts-conf/16657
+  echo '  <include ignore_missing="yes">/etc/fonts/conf.d</include>'
+  echo '  <include ignore_missing="yes">conf.d</include>'
+  
+  # We need to include this default cachedir first so that caching
+  # works: without it, fontconfig will try to write to the real user home
+  # cachedir and be blocked by AppArmor.
+  echo '  <cachedir prefix="xdg">fontconfig</cachedir>'
+  if [ -d $REALHOME/.cache/fontconfig ]; then
+    echo "  <cachedir>$REALHOME/.cache/fontconfig</cachedir>"
+  fi
+  echo "</fontconfig>"
+}
+
+if [ $needs_update = true ]; then
+  rm -rf $XDG_DATA_HOME/{fontconfig,fonts,fonts-*,themes,.themes}
+
+  # This fontconfig fragment is installed in a location that is
+  # included by the system fontconfig configuration: namely the
+  # etc/fonts/conf.d/50-user.conf file.
+  ensure_dir_exists $XDG_CONFIG_HOME/fontconfig
+  async_exec make_user_fontconfig > $XDG_CONFIG_HOME/fontconfig/fonts.conf
+
+  # the themes symlink are needed for GTK 3.18 when the prefix isn't changed
+  # GTK 3.20 looks into XDG_DATA_DIR which has connected themes.
+  if [ -d $SNAP/data-dir/themes ]; then
+    ln -sf $SNAP/data-dir/themes $XDG_DATA_HOME
+    ln -sfn $SNAP/data-dir/themes $SNAP_USER_DATA/.themes
+  else
+    ln -sf $RUNTIME/usr/share/themes $XDG_DATA_HOME
+    ln -sfn $RUNTIME/usr/share/themes $SNAP_USER_DATA/.themes
+  fi
+fi
+
+# Build mime.cache
+# needed for gtk and qt icon
+if [ $needs_update = true ]; then
+  rm -rf $XDG_DATA_HOME/mime
+  if [ ! -f $RUNTIME/usr/share/mime/mime.cache ]; then
+    if command -v update-mime-database >/dev/null; then
+      cp --preserve=timestamps -dR $RUNTIME/usr/share/mime $XDG_DATA_HOME
+      async_exec update-mime-database $XDG_DATA_HOME/mime
+    fi
+  fi
+fi
+
+# Gio modules and cache (including gsettings module)
+export GIO_MODULE_DIR=$XDG_CACHE_HOME/gio-modules
+function compile_giomodules {
+  if [ -f $1/glib-2.0/gio-querymodules ]; then
+    rm -rf $GIO_MODULE_DIR
+    ensure_dir_exists $GIO_MODULE_DIR
+    ln -s $1/gio/modules/*.so $GIO_MODULE_DIR
+    $1/glib-2.0/gio-querymodules $GIO_MODULE_DIR
+  fi
+}
+if [ $needs_update = true ]; then
+  async_exec compile_giomodules $RUNTIME/usr/lib/$ARCH
+fi
+
+# Setup compiled gsettings schema
+GS_SCHEMA_DIR=$XDG_DATA_HOME/glib-2.0/schemas
+function compile_schemas {
+  if [ -f "$1" ]; then
+    rm -rf $GS_SCHEMA_DIR
+    ensure_dir_exists $GS_SCHEMA_DIR
+    for ((i = 0; i < ${#data_dirs_array[@]}; i++)); do
+      schema_dir="${data_dirs_array[$i]}/glib-2.0/schemas"
+      if [ -f "$schema_dir/gschemas.compiled" ]; then
+        # This directory already has compiled schemas
+        continue
+      fi
+      if [ -n "$(ls -A $schema_dir/*.xml 2>/dev/null)" ]; then
+        ln -s $schema_dir/*.xml $GS_SCHEMA_DIR
+      fi
+      if [ -n "$(ls -A $schema_dir/*.override 2>/dev/null)" ]; then
+        ln -s $schema_dir/*.override $GS_SCHEMA_DIR
+      fi
+    done
+    # Only compile schemas if we copied anyting
+    if [ -n "$(ls -A $GS_SCHEMA_DIR/*.xml $GS_SCHEMA_DIR/*.override 2>/dev/null)" ]; then
+      "$1" $GS_SCHEMA_DIR
+    fi
+  fi
+}
+if [ $needs_update = true ]; then
+  async_exec compile_schemas $RUNTIME/usr/lib/$ARCH/glib-2.0/glib-compile-schemas
+fi
+
+# Enable gsettings user changes
+# symlink the dconf file if home plug is connected for read
+DCONF_DEST_USER_DIR=$SNAP_USER_DATA/.config/dconf
+if [ ! -f $DCONF_DEST_USER_DIR/user ]; then
+  if [ -f $REALHOME/.config/dconf/user ]; then
+    ensure_dir_exists $DCONF_DEST_USER_DIR
+    ln -s $REALHOME/.config/dconf/user $DCONF_DEST_USER_DIR
+  fi
+fi
+# symlink the runtime dconf file as well
+if [ -r $XDG_RUNTIME_DIR/../dconf/user ]; then
+  ensure_dir_exists $XDG_RUNTIME_DIR/dconf
+  ln -sf ../../dconf/user $XDG_RUNTIME_DIR/dconf/user
+fi
+
+# Testability support
+append_dir LD_LIBRARY_PATH $SNAP/testability
+append_dir LD_LIBRARY_PATH $SNAP/testability/$ARCH
+append_dir LD_LIBRARY_PATH $SNAP/testability/$ARCH/mesa
+
+# Gdk-pixbuf loaders
+export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache
+export GDK_PIXBUF_MODULEDIR=$RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
+if [ $needs_update = true ] || [ ! -f $GDK_PIXBUF_MODULE_FILE ]; then
+  rm -f $GDK_PIXBUF_MODULE_FILE
+  if [ -f $RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
+    async_exec $RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
+  fi
+fi
+
+# Icon themes cache
+if [ $needs_update = true ]; then
+  rm -rf $XDG_DATA_HOME/icons
+  ensure_dir_exists $XDG_DATA_HOME/icons
+  for ((i = 0; i < ${#data_dirs_array[@]}; i++)); do
+    # The runtime and theme content snaps should already contain icon caches
+    # so we skip them to optimise app start time.
+    if [[ "${data_dirs_array[$i]}" == "$SNAP/data-dir" || "${data_dirs_array[$i]}" == "$RUNTIME/"* ]]; then
+      continue
+    fi
+    for theme in "${data_dirs_array[$i]}/icons/"*; do
+      if [ -f "$theme/index.theme" -a ! -f "$theme/icon-theme.cache" ]; then
+        theme_dir=$XDG_DATA_HOME/icons/$(basename "$theme")
+        if [ ! -d "$theme_dir" ]; then
+          ensure_dir_exists "$theme_dir"
+          ln -s $theme/* "$theme_dir"
+          if [ -f $RUNTIME/usr/sbin/update-icon-caches ]; then
+            async_exec $RUNTIME/usr/sbin/update-icon-caches "$theme_dir"
+          elif [ -f $RUNTIME/usr/sbin/update-icon-cache.gtk2 ]; then
+            async_exec $RUNTIME/usr/sbin/update-icon-cache.gtk2 "$theme_dir"
+          fi
+        fi
+      fi
+    done
+  done
+fi
+
+# GTK theme and behavior modifier
+# Those can impact the theme engine used by Qt as well
+gtk_configs=(gtk-3.0/settings.ini gtk-3.0/bookmarks gtk-2.0/gtkfilechooser.ini)
+for f in ${gtk_configs[@]}; do
+  dest="$XDG_CONFIG_HOME/$f"
+  if [ ! -L "$dest" ]; then
+    ensure_dir_exists `dirname $dest`
+    ln -s $REALHOME/.config/$f $dest
+  fi
+done
+
+# create symbolic link to ibus socket path for ibus to look up its socket files
+# (see comments #3 and #6 on https://launchpad.net/bugs/1580463)
+IBUS_CONFIG_PATH=$XDG_CONFIG_HOME/ibus
+ensure_dir_exists $IBUS_CONFIG_PATH
+[ -d $IBUS_CONFIG_PATH/bus ] && rm -rf $IBUS_CONFIG_PATH/bus
+ln -sfn $REALHOME/.config/ibus/bus $IBUS_CONFIG_PATH
+##############################
+# Glib minimum specific part #
+##############################
+
+###############################
+# Mark update and exec binary #
+###############################
+
+[ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > $SNAP_USER_DATA/.last_revision
+
+wait_for_async_execs
+
+if [ -n "$SNAP_DESKTOP_DEBUG" ]; then
+  echo "desktop-launch elapsed time: " $(date +%s.%N --date="$START seconds ago") 
+  echo "Now running: exec $@"
+fi
+
+exec "$@"

--- a/snap/local/desktop-glib-only/desktop-launch
+++ b/snap/local/desktop-glib-only/desktop-launch
@@ -284,6 +284,9 @@ fi
 # Create links for user-dirs.dirs
 if [ $needs_xdg_links = true ]; then
   for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
+	if [ -z "${XDG_SPECIAL_DIRS_PATHS[$i]}" ]; then
+		continue
+    fi
     b=$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME")
     if [[ "$b" != "." && -e $REALHOME/$b ]]; then
       [ -d $HOME/$b ] && rmdir $HOME/$b 2> /dev/null

--- a/snap/local/ffmpeg-wrapper
+++ b/snap/local/ffmpeg-wrapper
@@ -6,4 +6,17 @@ elif [ -d "${SNAP}/usr/lib/${SNAP_LAUNCHER_ARCH_TRIPLET}/alsa-lib" ]; then
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${SNAP}/usr/lib/${SNAP_LAUNCHER_ARCH_TRIPLET}/alsa-lib"
 fi
 
+if ! snapctl is-connected ffmpeg-2404
+then
+  echo "ERROR: the ffmpeg-2404 interface isn't connected."
+  echo "  Please install and connect a FFmpeg runtime provider."
+  echo ""
+  echo "The default provider is ffmpeg-2404, you can install it and connect by issuing:"
+  echo "  sudo snap install ffmpeg-2404"
+  echo "  sudo snap connect ${SNAP_INSTANCE_NAME}:ffmpeg-2404 ffmpeg-2404"
+  echo ""
+  echo "See https://github.com/snapcrafters/ffmpeg-2404-sdk for more information."
+  exit 1
+fi
+
 exec "${@}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -452,7 +452,7 @@ parts:
 apps:
   ffmpeg:
     command: usr/bin/ffmpeg
-    command-chain:
+    command-chain: &command-chain
       - bin/desktop-launch
       - bin/ffmpeg-wrapper
     plugs: &plugs
@@ -473,61 +473,41 @@ apps:
       - x11
   ffprobe:
     command: usr/bin/ffprobe
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   ffplay:
     command: usr/bin/ffplay
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   srt-ffplay:
     command: usr/bin/srt-ffplay
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   srt-file-transmit:
     command: usr/bin/srt-file-transmit
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   srt-live-transmit:
     command: usr/bin/srt-live-transmit
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   srt-tunnel:
     command: usr/bin/srt-tunnel
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   vainfo:
     command: usr/bin/vainfo
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   vdpauinfo:
     command: usr/bin/vdpauinfo
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   eglinfo:
     command: usr/bin/eglinfo
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs
   glxinfo:
     command: usr/bin/glxinfo
-    command-chain:
-      - bin/desktop-launch
-      - bin/ffmpeg-wrapper
+    command-chain: *command-chain
     plugs: *plugs

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,14 +29,15 @@ layout:
 
 parts:
   desktop-glib-only:
-    plugin: make
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: glib-only
+    plugin: dump
+    source: snap/local/desktop-glib-only
     build-packages:
       - libglib2.0-dev
     stage-packages:
       - libglib2.0-bin
       - shared-mime-info
+    organize:
+      desktop-launch: bin/
 
   nv-codec-headers:
     plugin: make
@@ -432,6 +433,8 @@ parts:
       - vdpauinfo
     organize:
       ffmpeg-wrapper: bin/
+    stage:
+      - -desktop-glib-only
 
   cleanup:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ffmpeg
-adopt-info: ffmpeg
+version: ffmpeg-2404
 summary: A complete solution to record, convert and stream audio and video.
 description: |
  FFmpeg is the leading multimedia framework, able to decode, encode,
@@ -8,24 +8,37 @@ description: |
  up to the cutting edge. No matter if they were designed by some standards
  committee, the community or a corporation.
 
-base: core20
+base: core24
 grade: stable
 confinement: strict
 compression: lzo
 
-architectures:
-  - build-on: amd64
-  - build-on: ppc64el
-  - build-on: arm64
-  - build-on: armhf
+platforms:
+  amd64:
+  ppc64el:
+  arm64:
+  armhf:
+
+plugs:
+  ffmpeg-2404:
+    interface: content
+    target: $SNAP/ffmpeg-platform
+    default-provider: ffmpeg-2404
+
+  gpu-2404:
+    interface: content
+    target: $SNAP/gpu-2404
+    default-provider: mesa-2404
 
 layout:
-  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib:
-    symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/alsa-lib:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/alsa-lib
   /usr/share/alsa:
     symlink: $SNAP/usr/share/alsa
-  /usr/share/libdrm/amdgpu.ids:
-    symlink: $SNAP/usr/share/libdrm/amdgpu.ids
+  /usr/share/libdrm:
+    bind: $SNAP/gpu-2404/libdrm
+  /usr/share/drirc.d:
+    symlink: $SNAP/gpu-2404/drirc.d
 
 parts:
   desktop-glib-only:
@@ -39,388 +52,43 @@ parts:
     organize:
       desktop-launch: bin/
 
-  nv-codec-headers:
-    plugin: make
-    source: https://github.com/FFmpeg/nv-codec-headers.git
-    source-branch: 'sdk/11.0'
-    make-parameters:
-      - PREFIX=/usr
-    build-packages:
-      - pkg-config
-    prime:
-      - -usr/include
-      - -usr/lib/pkgconfig
-
-  srt:
-    plugin: cmake
-    source: https://github.com/Haivision/srt.git
-    source-tag: 'v1.4.4'
-    cmake-parameters:
-      - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_C_FLAGS_RELEASE=-s
-      - -DCMAKE_CXX_FLAGS_RELEASE=-s
-      - -DENABLE_LOGGING=OFF
-      - -DENABLE_STATIC=OFF
-    build-packages:
-      - libssl-dev
-    prime:
-      - -usr/include
-      - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig
-
-  avisynth-plus:
-    plugin: cmake
-    source: https://github.com/AviSynth/AviSynthPlus.git
-    source-tag: 'v3.7.0'
-    cmake-parameters:
-      - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_C_FLAGS_RELEASE=-s
-      - -DCMAKE_CXX_FLAGS_RELEASE=-s
-    prime:
-      - -usr/include
-      - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig
-
-  x264:
-    plugin: autotools
-    source: https://code.videolan.org/videolan/x264.git
-    source-branch: 'stable'
-    autotools-configure-parameters:
-      - --prefix=/usr
-      - --disable-cli
-      - --enable-shared
-      - --enable-strip
-    build-packages:
-      - libva-dev
-      - nasm
-    prime:
-      - usr/lib
-      - -usr/lib/pkgconfig
-
-  aom:
-    plugin: cmake
-    source: https://aomedia.googlesource.com/aom.git
-    source-tag: 'v3.2.0'
-    cmake-parameters:
-      - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_C_FLAGS_RELEASE=-s
-      - -DCMAKE_CXX_FLAGS_RELEASE=-s
-      - -DCONFIG_MULTITHREAD=1
-      - -DBUILD_SHARED_LIBS=1
-      - -DENABLE_DOCS=0
-      - -DENABLE_EXAMPLES=0
-      - -DENABLE_TESTS=0
-    override-build: |
-      EXTRA_PARAMS=()
-      if [ "$SNAPCRAFT_TARGET_ARCH" = "armhf" ]; then
-        EXTRA_PARAMS+=(-DAOM_NEON_INTRIN_FLAG=-mfpu=neon)
-      fi
-      cmake $SNAPCRAFT_PART_SRC \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_FLAGS_RELEASE=-s \
-        -DCMAKE_CXX_FLAGS_RELEASE=-s \
-        -DCONFIG_MULTITHREAD=1 \
-        -DBUILD_SHARED_LIBS=1 \
-        -DENABLE_DOCS=0 \
-        -DENABLE_EXAMPLES=0 \
-        -DENABLE_TESTS=0 \
-        ${EXTRA_PARAMS[@]}
-
-      cmake --build . -j$(nproc)
-      DESTDIR=$SNAPCRAFT_PART_INSTALL cmake --install .
-    build-packages:
-      - ninja-build
-      - yasm
-    prime:
-      - -usr/include
-      - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libaom.a
-      - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig
-
-  dav1d:
-    plugin: meson
-    source: https://code.videolan.org/videolan/dav1d.git
-    source-tag: '0.9.2'
-    meson-parameters:
-      - --prefix=/usr
-      - --buildtype=release
-      - --strip
-      - -Denable_tools=false
-      - -Denable_tests=false
-    build-packages:
-      - libxxhash-dev
-    stage-packages:
-      - libxxhash0
-    prime:
-      - -usr/include
-      - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig
-
-  zimg:
-    plugin: autotools
-    source: https://github.com/sekrit-twc/zimg.git
-    source-tag: 'release-3.0.3'
-    autotools-configure-parameters:
-      - --prefix=/usr
-    prime:
-      - -usr/include
-      - -usr/lib/*.a
-      - -usr/lib/*.la
-      - -usr/lib/pkgconfig
-
   ffmpeg:
-    after:
-      - aom
-      - avisynth-plus
-      - dav1d
-      - desktop-glib-only
-      - nv-codec-headers
-      - srt
-      - x264
-      - zimg
-    plugin: autotools
+    plugin: nil
     source: https://github.com/FFmpeg/FFmpeg.git
-    source-branch: release/4.4
-    build-packages:
-      - flite1-dev
-      - libass-dev
-      - libbs2b-dev
-      - libbluray-dev
-      - libbz2-dev
-      - libcaca-dev
-      - libcdio-paranoia-dev
-      - libchromaprint-dev
-      - libcodec2-dev
-      - libdc1394-22-dev
-      - libdrm-dev
-      - libfribidi-dev
-      - libgme-dev
-      - libgnutls28-dev
-      - libgsm1-dev
-      - liblzma-dev
-      - libmp3lame-dev
-      - libomxil-bellagio-dev
-      - libopenal-dev
-      - libopencore-amrnb-dev
-      - libopencore-amrwb-dev
-      - libopenjp2-7-dev
-      - libopenmpt-dev
-      - libopus-dev
-      - libpulse-dev
-      - librsvg2-dev
-      - librubberband-dev
-      - libsctp-dev
-      - libsdl2-dev
-      - libshine-dev
-      - libsnappy-dev
-      - libsoxr-dev
-      - libspeex-dev
-      - libssh-gcrypt-dev
-      - libtesseract-dev
-      - libtheora-dev
-      - libtwolame-dev
-      - libva-dev
-      - libv4l-dev
-      - libvdpau-dev
-      - libvo-amrwbenc-dev
-      - libvorbis-dev
-      - libvpx-dev
-      - libvulkan-dev
-      - libwavpack-dev
-      - libwebp-dev
-      - libx265-dev
-      - libxcb-shape0-dev
-      - libxcb-shm0-dev
-      - libxcb-xfixes0-dev
-      - libxml2-dev
-      - libxv-dev
-      - libxvidcore-dev
-      - libzmq3-dev
-      - libzvbi-dev
-      - ocl-icd-opencl-dev
-      - opencl-headers
-      - pkg-config
-      - yasm
-      - on amd64:
-        - libcrystalhd-dev
-        # TODO: re-enable `nvidia-cuda*` if we can determine that we can ship non-free
-        # - nvidia-cuda-dev
-        # - nvidia-cuda-toolkit
-      - on i386:
-        - libcrystalhd-dev
     stage-packages:
-      - freeglut3
-      - libass9
-      - libbluray2
-      - libbs2b0
+      - libasound2t64
+      - libarchive13t64
       - libcaca0
-      - libcdio-paranoia2
-      - libchromaprint1
-      - libcodec2-0.9
-      - libdc1394-22
+      - libcairo2
       - libdrm2
-      - libflite1
-      - libfribidi0
-      - libglu1-mesa
-      - libgme0
-      - libgnutls30
-      - libgsm1
-      - libmp3lame0
-      - libopenal1
-      - libopencore-amrnb0
-      - libopencore-amrwb0
+      - libgomp1
+      - libfreetype6
+      - libldap2
+      - liblcms2-2
+      - libmpg123-0t64
+      - libogg0
       - libopenjp2-7
-      - libopenmpt0
       - libopus0
       - libpulse0
+      - libraw1394-11
       - librsvg2-2
-      - librubberband2
-      - libsdl2-2.0-0
-      - libshine3
-      - libslang2
-      - libsnappy1v5
-      - libsoxr0
-      - libspeex1
-      - libssh-gcrypt-4
-      - libtesseract4
-      - libtheora0
       - libtwolame0
-      - libusb-1.0-0
-      - libv4l-0
-      - libv4l2rds0
-      - libva-drm2
-      - libva-glx2
-      - libva-wayland2
-      - libvdpau-va-gl1
-      - libvo-amrwbenc0
-      - libvorbis0a
-      - libvorbisenc2
-      - libvpx6
-      - libvulkan1
-      - libwavpack1
-      - libwebp6
-      - libwebpmux3
-      - libx265-179
-      - libx11-6
-      - libxau6
-      - libxcb-shape0
+      - libv4l-0t64
+      - libvpx9
+      - libxcb1
       - libxcb-shm0
       - libxcb-xfixes0
-      - libxcb1
-      - libxdmcp6
-      - libxext6
-      - libxml2
-      - libxv1
-      - libxvidcore4
-      - libzmq5
-      - libzvbi0
-      - mesa-vdpau-drivers
-      - ocl-icd-libopencl1
-      - on amd64:
-        - mesa-va-drivers
-        - libcrystalhd3
-        # TODO: re-enable `libnpp*` if we can determine that we can ship non-free
-        # - libnppig10
-        # - libnppicc10
-        # - libnppidei10
-      - on i386:
-        - mesa-va-drivers
-        - libcrystalhd3
-    override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version "$(git describe --tags)"
-    override-build: |
-      if [ "$SNAPCRAFT_TARGET_ARCH" = "amd64" ]; then
-        # TODO: re-enable `--enable-cuda-sdk --enable-cuda --enable-libnpp` if we can determine that we can ship non-free
-        EXTRA="--enable-vdpau --enable-nvenc --enable-cuvid"
-      elif [ "$SNAPCRAFT_TARGET_ARCH" = "i386" ]; then
-        EXTRA="--enable-vdpau --enable-nvenc"
-      elif [ "$SNAPCRAFT_TARGET_ARCH" = "armhf" ]; then
-        EXTRA="--disable-vdpau --enable-neon"
-      elif [ "$SNAPCRAFT_TARGET_ARCH" = "arm64" ]; then
-        EXTRA="--disable-vdpau"
-      else
-        EXTRA=""
-      fi
-      ./configure \
-      --prefix=/usr \
-      --disable-debug \
-      --disable-doc \
-      --disable-libfdk-aac \
-      --disable-static \
-      --enable-libaom \
-      --enable-avisynth \
-      --enable-chromaprint \
-      --enable-libdav1d \
-      --enable-ffplay \
-      --enable-gnutls \
-      --enable-gpl \
-      --enable-libass \
-      --enable-libbluray \
-      --enable-libbs2b \
-      --enable-libcaca \
-      --enable-libcdio \
-      --enable-libcodec2 \
-      --enable-libdc1394 \
-      --enable-libdrm \
-      --enable-libflite \
-      --enable-libfontconfig \
-      --enable-libfribidi \
-      --enable-libfreetype \
-      --enable-libgme \
-      --enable-libgsm \
-      --enable-libmp3lame \
-      --enable-libopencore_amrnb \
-      --enable-libopencore_amrwb \
-      --enable-libopenjpeg \
-      --enable-libopenmpt \
-      --enable-libopus \
-      --enable-libpulse \
-      --enable-librsvg \
-      --enable-librubberband \
-      --enable-libshine \
-      --enable-libsnappy \
-      --enable-libsoxr \
-      --enable-libspeex \
-      --enable-libsrt \
-      --enable-libssh \
-      --enable-libtesseract \
-      --enable-libtheora \
-      --enable-libtwolame \
-      --enable-libv4l2 \
-      --enable-libvo_amrwbenc \
-      --enable-libvorbis \
-      --enable-libvpx \
-      --enable-libwebp \
-      --enable-libx264 \
-      --enable-libx265 \
-      --enable-libxcb \
-      --enable-libxml2 \
-      --enable-libxvid \
-      --enable-libzimg \
-      --enable-libzmq \
-      --enable-libzvbi \
-      --enable-omx \
-      --enable-openal \
-      --enable-opencl \
-      --enable-opengl \
-      --enable-runtime-cpudetect \
-      --enable-sdl2 \
-      --enable-shared \
-      --enable-vaapi \
-      --enable-version3 \
-      --enable-vulkan \
-      --enable-xlib ${EXTRA}
-      
-      # TODO: re-enable `--enable-nonfree \` if we can determine the legality/licensing issues are ok.
-      
-      make -j $(nproc)
-      make DESTDIR="$SNAPCRAFT_PART_INSTALL" install
+      - libxcursor1
+      - libxi6
+      - libxkbcommon0
+      - libxrandr2
+      - libspeex1
+      - libtheora0
+      - libwebp7
+      - libwebpmux3
     prime:
       - -usr/include
       - -usr/lib/pkgconfig
-      - -usr/share/ffmpeg/examples
-      - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libx264.so*
 
   ffmpeg-wrapper:
     plugin: dump
@@ -432,6 +100,7 @@ parts:
       - vainfo
       - vdpauinfo
     organize:
+      content-snap-executable-wrapper: bin/
       ffmpeg-wrapper: bin/
     stage:
       - -desktop-glib-only
@@ -449,12 +118,45 @@ parts:
       rm ${SNAPCRAFT_PRIME}/usr/share/doc/*/README* 2>/dev/null || true
       find ${SNAPCRAFT_PRIME}/usr -type d -empty -delete || true
 
+  gpu-2404:
+    after:
+      - ffmpeg-wrapper
+    source: https://github.com/canonical/gpu-snap.git
+    plugin: dump
+    override-prime: |
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
+      # Workaround for https://bugs.launchpad.net/snapd/+bug/2055273
+      mkdir -p "${CRAFT_PRIME}/gpu-2404"
+    prime:
+      - bin/gpu-2404-wrapper
+
+  ffmpeg-2404:
+    after:
+      - gpu-2404
+    source: https://github.com/snapcrafters/ffmpeg-2404-sdk.git
+    plugin: nil
+    override-prime: |
+      craftctl default
+
+      # Workaround for https://bugs.launchpad.net/snapd/+bug/2055273
+      mkdir -p "${CRAFT_PRIME}/ffmpeg-platform"
+
+      for command in ffmpeg ffprobe ffplay srt-ffplay srt-file-transmit \
+        srt-live-transmit srt-tunnel vainfo vdpauinfo eglinfo glxinfo; do
+        ln -sv --relative --force "${CRAFT_PRIME}/bin/content-snap-executable-wrapper" \
+          "${CRAFT_PRIME}/bin/${command}"
+      done
+
 apps:
   ffmpeg:
-    command: usr/bin/ffmpeg
+    command: bin/ffmpeg
     command-chain: &command-chain
       - bin/desktop-launch
+      - bin/gpu-2404-wrapper
       - bin/ffmpeg-wrapper
+    environment: &environment
+      LD_LIBRARY_PATH: ${SNAP}/ffmpeg-platform/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${SNAP}/gpu-2404/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     plugs: &plugs
       - alsa
       - audio-playback
@@ -472,42 +174,52 @@ apps:
       - wayland
       - x11
   ffprobe:
-    command: usr/bin/ffprobe
+    command: bin/ffprobe
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   ffplay:
-    command: usr/bin/ffplay
+    command: bin/ffplay
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   srt-ffplay:
-    command: usr/bin/srt-ffplay
+    command: bin/srt-ffplay
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   srt-file-transmit:
-    command: usr/bin/srt-file-transmit
+    command: bin/srt-file-transmit
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   srt-live-transmit:
-    command: usr/bin/srt-live-transmit
+    command: bin/srt-live-transmit
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   srt-tunnel:
-    command: usr/bin/srt-tunnel
+    command: bin/srt-tunnel
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   vainfo:
-    command: usr/bin/vainfo
+    command: bin/vainfo
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   vdpauinfo:
-    command: usr/bin/vdpauinfo
+    command: bin/vdpauinfo
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   eglinfo:
-    command: usr/bin/eglinfo
+    command: bin/eglinfo
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs
   glxinfo:
-    command: usr/bin/glxinfo
+    command: bin/glxinfo
     command-chain: *command-chain
+    environment: *environment
     plugs: *plugs


### PR DESCRIPTION
This pull request:

* Migrates the base to core24
* Replaces FFmpeg and its dependencies with [the FFmpeg Content Snap](https://github.com/snapcrafters/ffmpeg-2404-sdk), which ships a more recent version(7.1.1 at the moment)
* Replaces mesa packages with the ones provided by [the mesa-2404 content snap](https://canonical.com/mir/docs/the-gpu-2404-snap-interface)
* Introduces [a wrapper](https://github.com/brlin-tw/ffmpeg-snap/blob/content-snap/snap/local/content-snap-executable-wrapper) to [bypass Snapcraft's application executable existence checks](https://github.com/brlin-tw/ffmpeg-snap/blob/6264dfd/snap/snapcraft.yaml#L145-L149) as the app commands are now provided by the content snaps
* Vendors [a copy of the now-obsoleted glib-only desktop helper launcher](https://github.com/brlin-tw/ffmpeg-snap/blob/content-snap/snap/local/desktop-glib-only/desktop-launch), with some patches to fix known issues.
* Simplifies a bit of the Snapcraft project file

Refer to the individual commits for more information.

Fixes #77.

I've tested that:

* test.sh works for a VA-API capable hardware
* `ffmpeg.ffplay` works
* `ffmpeg.ffprobe` works
* `ffmpeg.eglinfo` works
* `ffmpeg.glxinfo` works
* `ffmpeg.vainfo` works